### PR TITLE
Bug-fix #7 - Adding whitespace between // and MARK

### DIFF
--- a/MarkExtension/MarkParser.swift
+++ b/MarkExtension/MarkParser.swift
@@ -132,7 +132,7 @@ class MarkParser {
             for name in protocolNames {
                 let protocolName = name.alphabeticalString().fromCamelCase()
                 linesToInsert.append("\n")
-                linesToInsert.append("\(ind)//MARK: - \(protocolName)\n")
+                linesToInsert.append("\(ind)// MARK: - \(protocolName)\n")
             }
         }
         return linesToInsert


### PR DESCRIPTION
Adds a white space between // and MARK